### PR TITLE
Diagnose build failure from project inspection

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@
  */
 import java.io.ByteArrayOutputStream
 
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.kopi.gradle.common._project
 import org.kopi.gradle.common.clean
 import org.kopi.gradle.common.withExtension
@@ -47,6 +48,12 @@ apply(from = "declarations.gradle.kts")
 plugins {
   kotlin("jvm") version "1.5.30"
   id("io.spring.dependency-management") version "1.0.10.RELEASE"
+}
+
+java {
+  toolchain {
+    languageVersion.set(JavaLanguageVersion.of(11))
+  }
 }
 
 sourceSets.main {
@@ -139,10 +146,14 @@ modules.init()
 
 tasks {
   compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "11"
   }
   compileKotlin {
     destinationDir = file(classRoot!!)
+
+    kotlinOptions {
+      jvmTarget = "11"
+    }
 
     if(jdk7Home != null) {
       sourceCompatibility = "1.7"
@@ -358,6 +369,8 @@ tasks.withType<JavaCompile>().configureEach {
       sourceCompatibility = "1.7"
       targetCompatibility = "1.7"
       forkOptions.javaHome = file(jdk7Home)
+    } else {
+      release.set(11)
     }
     isFork = true
     isFailOnError = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,5 @@
 ##
 
 org.gradle.daemon=true
-org.gradle.jvmargs=-Xmx2g
+org.gradle.jvmargs=-Xmx2g --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+kotlin.daemon.jvm.options=--add-opens=java.base/sun.nio.ch=ALL-UNNAMED


### PR DESCRIPTION
Align Java and Kotlin compilation to target Java 11 and configure the Gradle build environment for JDK 11.

The initial build failed due to a JVM target mismatch (Java 11 vs Kotlin 1.8). This PR updates the `build.gradle.kts` to use Java 11 toolchains and sets the Kotlin `jvmTarget` to 11. It also adds necessary `--add-opens` JVM arguments to `gradle.properties` for the Kotlin daemon to ensure compatibility with newer JDKs. This resolves the target mismatch, allowing the build to proceed past this configuration issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-13ab5760-4ca4-494c-9c84-f92095ceabbd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-13ab5760-4ca4-494c-9c84-f92095ceabbd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

